### PR TITLE
Should enforce metafields value is json flag

### DIFF
--- a/tap_shopify/schemas/metafields.json
+++ b/tap_shopify/schemas/metafields.json
@@ -63,7 +63,8 @@
         "array",
         "string"
       ],
-      "properties": {}
+      "properties": {},
+      "items": []
     },
     "updated_at": {
       "type": [

--- a/tap_shopify/schemas/metafields.json
+++ b/tap_shopify/schemas/metafields.json
@@ -60,6 +60,7 @@
         "null",
         "integer",
         "object",
+        "array",
         "string"
       ],
       "properties": {}

--- a/tap_shopify/streams/metafields.py
+++ b/tap_shopify/streams/metafields.py
@@ -26,6 +26,11 @@ def get_metafields(parent_object, since_id):
 class Metafields(Stream):
     name = 'metafields'
     replication_object = shopify.Metafield
+    should_enforce_value_is_json = None
+
+    def __init__(self, *args, **kwargs):
+        super(*args, **kwargs)
+        self.should_enforce_value_is_json = Context.config.get('metafields_value_should_enforce_json', False)
 
     def get_objects(self):
         # Get top-level shop metafields
@@ -65,6 +70,9 @@ class Metafields(Stream):
                 except json.decoder.JSONDecodeError:
                     LOGGER.info("Failed to decode JSON value for metafield %s", metafield.get('id'))
                     metafield["value"] = value
+            elif self.should_enforce_value_is_json and value_type and value_type == "string":
+                value = metafield.get("value")
+                metafield["value"] = json.dumps(value) if value is not None else value
 
             yield metafield
 


### PR DESCRIPTION
https://github.com/transferwise/pipelinewise-target-postgres currently does not support the schema of metafields.value because it has integer/string/object. The destination column is jsonb, and a raw string needs to be "quoted" to be valid jsonb. 

This adds a flag to enforce the emitted values to be json (quotes strings) as a stopgap until this is fixed in the target.

https://github.com/transferwise/pipelinewise-target-postgres/issues/43